### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/org.cubocore.CoreKeyboard.yml
+++ b/org.cubocore.CoreKeyboard.yml
@@ -8,7 +8,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --device=dri
-  - --filesystem=xdg-config:create # flatpak linter causes error on xdg-config
+  - --filesystem=home
   - --talk-name=org.kde.StatusNotifierWatcher
 cleanup:
   - /include

--- a/org.cubocore.CoreKeyboard.yml
+++ b/org.cubocore.CoreKeyboard.yml
@@ -10,7 +10,6 @@ finish-args:
   - --device=dri
   - --filesystem=xdg-config:create # flatpak linter causes error on xdg-config
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.* # For showing in the system tray
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025